### PR TITLE
Apply URI encode to links

### DIFF
--- a/src/search/common.ts
+++ b/src/search/common.ts
@@ -53,7 +53,7 @@ export const dictionarySearch: SearchFunc = async (word: string, lang: string) =
     ret.push({
       from: item[0][0],
       to: item[3].join(","),
-      link: `dict.naver.com/${convertLang(lang)}kodict/#/search?query=${item[0][0]}`,
+      link: encodeURI(`dict.naver.com/${convertLang(lang)}kodict/#/search?query=${item[0][0]}`),
     });
   });
   return ret;

--- a/src/search/english.ts
+++ b/src/search/english.ts
@@ -28,7 +28,7 @@ export const englishSearch: SearchFunc = async (word: string) => {
       ret.push({
         from: item[0][0],
         to: item[1].join(","),
-        link: `https://en.dict.naver.com/#/search?range=all&query=${item[0][0]}`,
+        link: encodeURI(`https://en.dict.naver.com/#/search?range=all&query=${item[0][0]}`),
       });
     });
   });

--- a/src/search/korean.ts
+++ b/src/search/korean.ts
@@ -26,7 +26,7 @@ export const koreanSearch: SearchFunc = async (word: string) => {
     ret.push({
       from: item[0][0],
       to: "",
-      link: `https://ko.dict.naver.com/#/search?query=${item[0][0]}`,
+      link: encodeURI(`https://ko.dict.naver.com/#/search?query=${item[0][0]}`),
     });
   });
   return ret;


### PR DESCRIPTION
If a link contained characters that were not URL encoded, such as Korean, the error `Could not open app Error: Could not open URL` would occur.
To resolve this issue, we should use `EncodeURI` function to encode all links.